### PR TITLE
Remove allowBackup and supportsRtl from AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,10 +2,7 @@
     package="com.github.wusuopu.RNEmulatorCheck">
 
     <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
+        android:label="@string/app_name">
     </application>
 
 </manifest>


### PR DESCRIPTION
The library should not set android:allowBackup or android:supportsRtl to avoid manifest merge failure when they are set to other values in a project which uses the library.